### PR TITLE
Improved content handling

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/image/PSDParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/image/PSDParser.java
@@ -197,6 +197,11 @@ public class PSDParser extends AbstractParser {
             read += 4;
             readMarker = read;
 
+            // Extra layer of protection, trying to avoid running out of stream
+            if( read + extraDataFieldLength > layerInfoSectionSize + 1) {
+                break;
+            }
+
             // 4 bytes - length of mask/adjustment layer (retrieve and skip)
             maskAdjustmentLength = EndianUtils.readIntBE(stream);
             // 4 bytes - length of layer blending ranges (retrieve and skip)

--- a/tika-parsers/src/main/java/org/apache/tika/parser/image/PSDParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/image/PSDParser.java
@@ -430,7 +430,9 @@ public class PSDParser extends AbstractParser {
         }
 //        System.out.printf("read: %d, total: %d\n", read, layerInfoSectionSize);
 //        System.out.println("Done with PSD Layers");
-        metadata.set(Photoshop.LAYER_NAMES, names);
+        if(names.length > 0) {
+            metadata.set(Photoshop.LAYER_NAMES, names);
+        }
 
         // Finally we have Image Data
         // We can't do anything with these parts
@@ -438,14 +440,16 @@ public class PSDParser extends AbstractParser {
         // Add the text layer bodies as the body of text
         XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
         xhtml.startDocument();
-        xhtml.startElement("p");
-        for (String text : textFields) {
-            if (text.length() > 0) {
-                xhtml.characters(text.toCharArray(), 0, text.toCharArray().length);
-                xhtml.newline();
+        if(textFields.length > 0) {
+            xhtml.startElement("p");
+            for (String text : textFields) {
+                if (text.length() > 0) {
+                    xhtml.characters(text.toCharArray(), 0, text.toCharArray().length);
+                    xhtml.newline();
+                }
             }
+            xhtml.endElement("p");
         }
-        xhtml.endElement("p");
         xhtml.endDocument();
     }
 


### PR DESCRIPTION
+ The key `Photoshop.LAYER_NAMES` was being added even when no layer names were found, causing an error down stream. This is fixed
+ Made sure no `<p>` tags are added to the text body if there is no text extracted
+ There is an error occurring where the steam ends unexpectedly. An additional check has been added to avoid reading past the end of the stream. I have no test files that cause this behavior, so the check is a precaution and a guess.

